### PR TITLE
Deletion of WebPFreeDecBuffer

### DIFF
--- a/extractor.c
+++ b/extractor.c
@@ -112,7 +112,6 @@ cleanup:
 		LocalFree(*h_bitmap_info);
 		*h_bitmap_info = NULL;
 	}
-	WebPFreeDecBuffer(&config.output);
 
 	return ret_result;
 }


### PR DESCRIPTION
No need to call WebPFreeDecBuffer because config.output.is_external_memory = 1.