### PR TITLE
Fix wrong header size

### DIFF
--- a/extractor.c
+++ b/extractor.c
@@ -80,7 +80,7 @@ int getBMPFromWebP(const uint8_t *input_data, size_t file_size,
 		goto cleanup;
 	}
 
-	bitmap_info_header->biSize = sizeof(BITMAPINFOHEADER);
+	bitmap_info_header->biSize = sizeof(BITMAPINFO);
 	bitmap_info_header->biWidth = width;
 	bitmap_info_header->biHeight = height;
 	bitmap_info_header->biPlanes = 1;


### PR DESCRIPTION
There was a missing correction in the fix for Pull Request #3. I had allocated memory with a size of `sizeof(BITMAPINFO)` bytes, but forgot to update the size stored in the header accordingly. This has now been fixed.